### PR TITLE
[kf5-calendarcore] Update to latest upstream 5.90.

### DIFF
--- a/rpm/0001-Adjust-for-lower-Qt-versions.patch
+++ b/rpm/0001-Adjust-for-lower-Qt-versions.patch
@@ -4,32 +4,36 @@ Date: Tue, 14 May 2019 11:35:15 +0200
 Subject: [PATCH] Adjust for lower Qt versions.
 
 ---
- CMakeLists.txt                      |  7 ++-----
+ CMakeLists.txt                      | 13 +++++-------
  autotests/testdateserialization.cpp |  8 ++++++++
+ autotests/testevent.cpp             |  2 +-
+ autotests/testfreebusy.cpp          |  2 +-
  autotests/testfreebusyperiod.cpp    |  4 ++++
  autotests/testicalformat.cpp        |  8 ++++++--
+ autotests/testincidence.cpp         |  6 +++---
  autotests/testmemorycalendar.cpp    |  2 +-
  autotests/testrecurtodo.cpp         |  5 +++++
  autotests/testtimesininterval.cpp   | 12 +++++++++++
- src/CMakeLists.txt                  |  1 +
+ src/CMakeLists.txt                  |  3 ++-
+ src/attendee.h                      |  1 +
  src/calendar.cpp                    |  1 +
  src/icalformat.cpp                  |  1 +
  src/icalformat_p.cpp                |  5 ++++-
  src/occurrenceiterator.cpp          |  1 +
  src/recurrencerule.cpp              | 32 +++++++++++++++++++++++++++++
  src/utils_p.h                       |  8 ++++++++
- 14 files changed, 86 insertions(+), 9 deletions(-)
+ 18 files changed, 96 insertions(+), 18 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 8672c2327..9f13b11af 100644
+index 406925e2b..f39c15fab 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -5,17 +5,16 @@ project(KCalendarCore VERSION ${KF_VERSION})
+@@ -5,13 +5,13 @@ project(KCalendarCore VERSION ${KF_VERSION})
  
  # ECM setup
  include(FeatureSummary)
--find_package(ECM 5.86.0  NO_MODULE)
-+find_package(ECM 5.75.0  NO_MODULE)
+-find_package(ECM 5.90.0  NO_MODULE)
++find_package(ECM 5.89.0  NO_MODULE)
  set_package_properties(ECM PROPERTIES TYPE REQUIRED DESCRIPTION "Extra CMake Modules." URL "https://commits.kde.org/extra-cmake-modules")
  feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND FATAL_ON_MISSING_REQUIRED_PACKAGES)
  
@@ -40,16 +44,6 @@ index 8672c2327..9f13b11af 100644
  
  include(KDEInstallDirs)
  include(KDECMakeSettings)
--include(KDEGitCommitHooks)
- include(KDEFrameworkCompilerSettings NO_POLICY_SCOPE)
- 
- include(ECMGenerateExportHeader)
-@@ -125,5 +124,3 @@ if (NOT WIN32)
- endif()
- 
- feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)
--
--kde_configure_git_pre_commit_hook(CHECKS CLANG_FORMAT)
 diff --git a/autotests/testdateserialization.cpp b/autotests/testdateserialization.cpp
 index 4c821d45b..9bc28ff9c 100644
 --- a/autotests/testdateserialization.cpp
@@ -78,11 +72,37 @@ index 4c821d45b..9bc28ff9c 100644
      QDateTime dueDate{startDate.addDays(1)};
  
      Todo::Ptr todo(new Todo);
+diff --git a/autotests/testevent.cpp b/autotests/testevent.cpp
+index c1a090c5f..d6f414938 100644
+--- a/autotests/testevent.cpp
++++ b/autotests/testevent.cpp
+@@ -178,7 +178,7 @@ void EventTest::testAssign()
+ 
+     IncidenceBase *event2 = new Event;
+     *event2 = event1;     // Use IncidenceBase's virtual assignment.
+-    QCOMPARE(event1, *event2);
++    QCOMPARE(event1, *static_cast<Event*>(event2));
+ }
+ 
+ void EventTest::testSerializer_data()
+diff --git a/autotests/testfreebusy.cpp b/autotests/testfreebusy.cpp
+index c4c7802a4..ce55355c4 100644
+--- a/autotests/testfreebusy.cpp
++++ b/autotests/testfreebusy.cpp
+@@ -63,7 +63,7 @@ void FreeBusyTest::testAssign()
+ 
+     IncidenceBase *fb2 = new FreeBusy;
+     *fb2 = fb1;     // Use IncidenceBase's virtual assignment.
+-    QCOMPARE(fb1, *fb2);
++    QCOMPARE(fb1, *static_cast<FreeBusy*>(fb2));
+ 
+     fb1.setDtStart(firstDateTime.addDays(1));
+     fb2->setDtStart(firstDateTime.addDays(2));
 diff --git a/autotests/testfreebusyperiod.cpp b/autotests/testfreebusyperiod.cpp
-index 118838b33..b686efb9c 100644
+index 8bee5dc4b..f258d7306 100644
 --- a/autotests/testfreebusyperiod.cpp
 +++ b/autotests/testfreebusyperiod.cpp
-@@ -84,7 +84,11 @@ void FreeBusyPeriodTest::testDataStreamOut()
+@@ -103,7 +103,11 @@ void FreeBusyPeriodTest::testDataStreamOut()
  
  void FreeBusyPeriodTest::testDataStreamIn()
  {
@@ -95,7 +115,7 @@ index 118838b33..b686efb9c 100644
      FreeBusyPeriod p1(p1DateTime, duration);
      p1.setSummary(QStringLiteral("I can haz summary?"));
 diff --git a/autotests/testicalformat.cpp b/autotests/testicalformat.cpp
-index 174a0ac5f..880a63d5c 100644
+index 78d9d6a73..c5647df12 100644
 --- a/autotests/testicalformat.cpp
 +++ b/autotests/testicalformat.cpp
 @@ -204,7 +204,11 @@ void ICalFormatTest::testAlarm()
@@ -128,6 +148,36 @@ index 174a0ac5f..880a63d5c 100644
      QTest::newRow("UTC time")
          << QByteArray("DTSTART:20191113T130000Z")
          << QDateTime(QDate(2019, 11, 13), QTime(13, 00), Qt::UTC);
+diff --git a/autotests/testincidence.cpp b/autotests/testincidence.cpp
+index 6183acf1f..c2789700b 100644
+--- a/autotests/testincidence.cpp
++++ b/autotests/testincidence.cpp
+@@ -103,14 +103,14 @@ void IncidenceTest::testGeo()
+     QCOMPARE(inc.hasGeo(), true);
+     QCOMPARE(inc.geoLatitude(), 90.0);
+     QCOMPARE(inc.geoLongitude(), 180.0);
+-    QCOMPARE(inc.dirtyFields(), (QSet{IncidenceBase::FieldGeoLatitude, IncidenceBase::FieldGeoLongitude}));
++    QCOMPARE(inc.dirtyFields(), (QSet<IncidenceBase::Field>() << IncidenceBase::FieldGeoLatitude << IncidenceBase::FieldGeoLongitude));
+     inc.resetDirtyFields();
+     inc.setGeoLatitude(-90.0);
+     inc.setGeoLongitude(-180.0);
+     QCOMPARE(inc.hasGeo(), true);
+     QCOMPARE(inc.geoLatitude(), -90.0);
+     QCOMPARE(inc.geoLongitude(), -180.0);
+-    QCOMPARE(inc.dirtyFields(), (QSet{IncidenceBase::FieldGeoLatitude, IncidenceBase::FieldGeoLongitude}));
++    QCOMPARE(inc.dirtyFields(), (QSet<IncidenceBase::Field>() << IncidenceBase::FieldGeoLatitude << IncidenceBase::FieldGeoLongitude));
+ 
+     // Clear GEO, thoroughly.
+     inc.resetDirtyFields();
+@@ -122,7 +122,7 @@ void IncidenceTest::testGeo()
+     QCOMPARE(inc.hasGeo(), false);
+     QCOMPARE(inc.geoLatitude(), INVALID_LATLON);
+     QCOMPARE(inc.geoLongitude(), INVALID_LATLON);
+-    QCOMPARE(inc.dirtyFields(), (QSet{IncidenceBase::FieldGeoLatitude, IncidenceBase::FieldGeoLongitude}));
++    QCOMPARE(inc.dirtyFields(), (QSet<IncidenceBase::Field>() << IncidenceBase::FieldGeoLatitude << IncidenceBase::FieldGeoLongitude));
+ 
+     // Error handling.
+ #if KCALENDARCORE_BUILD_DEPRECATED_SINCE(5, 89)
 diff --git a/autotests/testmemorycalendar.cpp b/autotests/testmemorycalendar.cpp
 index ec62d7681..8f2a45fef 100644
 --- a/autotests/testmemorycalendar.cpp
@@ -198,23 +248,23 @@ index b07906277..809f1fd3d 100644
      }
      QCOMPARE(timesInInterval.size(), expectedDays.size());
  }
-diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 9ad4f984d..663e1844d 100644
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
-@@ -44,6 +44,7 @@ target_sources(KF5CalendarCore PRIVATE
-   utils.cpp
-   vcalformat.cpp
-   visitor.cpp
-+  kcalendarcore_debug.cpp
- )
- ecm_qt_declare_logging_category(KF5CalendarCore
-     HEADER kcalendarcore_debug.h
+diff --git a/src/attendee.h b/src/attendee.h
+index 420699b13..5a9b8e125 100644
+--- a/src/attendee.h
++++ b/src/attendee.h
+@@ -18,6 +18,7 @@
+ 
+ #include <QMetaType>
+ #include <QSharedDataPointer>
++#include <QVector>
+ 
+ #include "customproperties.h"
+ #include "kcalendarcore_export.h"
 diff --git a/src/calendar.cpp b/src/calendar.cpp
-index 585469598..2a4fef1d0 100644
+index 12a1a88f7..ca11e226e 100644
 --- a/src/calendar.cpp
 +++ b/src/calendar.cpp
-@@ -27,6 +27,7 @@
+@@ -28,6 +28,7 @@
  #include "icaltimezones_p.h"
  #include "sorting.h"
  #include "visitor.h"
@@ -235,7 +285,7 @@ index d655599cc..17c8befbf 100644
  #include <QFile>
  #include <QSaveFile>
 diff --git a/src/icalformat_p.cpp b/src/icalformat_p.cpp
-index e6990dd0e..2563c8506 100644
+index 478196455..58b08f9b6 100644
 --- a/src/icalformat_p.cpp
 +++ b/src/icalformat_p.cpp
 @@ -28,6 +28,7 @@
@@ -246,7 +296,7 @@ index e6990dd0e..2563c8506 100644
  
  #include "kcalendarcore_debug.h"
  
-@@ -1739,7 +1740,7 @@ void ICalFormatImpl::readIncidence(icalcomponent *parent, const Incidence::Ptr &
+@@ -1741,7 +1742,7 @@ void ICalFormatImpl::readIncidence(icalcomponent *parent, const Incidence::Ptr &
              // We can't change that -- in order to retain backwards compatibility.
              text = icalproperty_get_categories(p);
              const QString val = QString::fromUtf8(text);
@@ -255,7 +305,7 @@ index e6990dd0e..2563c8506 100644
              for (const QString &cat : lstVal) {
                  // ensure no duplicates
                  if (!categories.contains(cat)) {
-@@ -2496,7 +2497,9 @@ QDateTime ICalFormatImpl::readICalDateTimeProperty(icalproperty *p, const ICalTi
+@@ -2495,7 +2496,9 @@ QDateTime ICalFormatImpl::readICalDateTimeProperty(icalproperty *p, const ICalTi
              break;
          }
      } // end of ICAL_X_PROPERTY
@@ -266,7 +316,7 @@ index e6990dd0e..2563c8506 100644
          switch (kind) {
          case ICAL_RDATE_PROPERTY:
 diff --git a/src/occurrenceiterator.cpp b/src/occurrenceiterator.cpp
-index 5e34a1f6b..bc7bd3311 100644
+index 96533282c..94d2660ad 100644
 --- a/src/occurrenceiterator.cpp
 +++ b/src/occurrenceiterator.cpp
 @@ -19,6 +19,7 @@

--- a/rpm/0002-Revert-Port-QStringRef-deprecated-to-QStringView.patch
+++ b/rpm/0002-Revert-Port-QStringRef-deprecated-to-QStringView.patch
@@ -1,0 +1,238 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Damien Caliste <dcaliste@free.fr>
+Date: Wed, 5 Jan 2022 09:47:46 +0100
+Subject: [PATCH] Revert "Port QStringRef (deprecated) to QStringView"
+
+This reverts commit 80ccb98039bc361b6f3c45e7cf44c28d03b0844b.
+---
+ src/vcalformat.cpp | 109 +++++++++++++++++----------------------------
+ 1 file changed, 40 insertions(+), 69 deletions(-)
+
+diff --git a/src/vcalformat.cpp b/src/vcalformat.cpp
+index 5cf1d9fee..47442731e 100644
+--- a/src/vcalformat.cpp
++++ b/src/vcalformat.cpp
+@@ -321,15 +321,12 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
+         uint recurrenceType = Recurrence::rNone;
+         int recurrenceTypeAbbrLen = 0;
+ 
+-        s = fakeCString(vObjectUStringZValue(vo));
+-        QString tmpStr = QString::fromUtf8(s);
++        QString tmpStr = (QString::fromUtf8(s = fakeCString(vObjectUStringZValue(vo))));
+         deleteStr(s);
+         tmpStr = tmpStr.simplified();
+         const int tmpStrLen = tmpStr.length();
+         if (tmpStrLen > 0) {
+             tmpStr = tmpStr.toUpper();
+-            QStringView prefix = QStringView(tmpStr).left(2);
+-
+             // first, read the type of the recurrence
+             recurrenceTypeAbbrLen = 1;
+             if (tmpStr.at(0) == QLatin1Char('D')) {
+@@ -338,13 +335,13 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
+                 recurrenceType = Recurrence::rWeekly;
+             } else if (tmpStrLen > 1) {
+                 recurrenceTypeAbbrLen = 2;
+-                if (prefix == QLatin1String("MP")) {
++                if (tmpStr.leftRef(2) == QLatin1String("MP")) {
+                     recurrenceType = Recurrence::rMonthlyPos;
+-                } else if (prefix == QLatin1String("MD")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("MD")) {
+                     recurrenceType = Recurrence::rMonthlyDay;
+-                } else if (prefix == QLatin1String("YM")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("YM")) {
+                     recurrenceType = Recurrence::rYearlyMonth;
+-                } else if (prefix == QLatin1String("YD")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("YD")) {
+                     recurrenceType = Recurrence::rYearlyDay;
+                 }
+             }
+@@ -354,11 +351,7 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
+             // Immediately after the type is the frequency
+             int index = tmpStr.indexOf(QLatin1Char(' '));
+             int last = tmpStr.lastIndexOf(QLatin1Char(' ')) + 1; // find last entry
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-            const int rFreq = QStringView(tmpStr).mid(recurrenceTypeAbbrLen, (index - 1)).toInt();
+-#else
+-            const int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+-#endif
++            int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+             ++index; // advance to beginning of stuff after freq
+ 
+             // Read the type-specific settings
+@@ -492,12 +485,8 @@ Todo::Ptr VCalFormat::VTodoToEvent(VObject *vtodo)
+             index = last;
+             if (tmpStr.mid(index, 1) == QLatin1String("#")) {
+                 // Nr of occurrences
+-                ++index;
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-                const int rDuration = QStringView(tmpStr).mid(index, tmpStr.length() - index).toInt();
+-#else
+-                const int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+-#endif
++                index++;
++                int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+                 if (rDuration > 0) {
+                     anEvent->recurrence()->setDuration(rDuration);
+                 }
+@@ -772,8 +761,6 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
+         const int tmpStrLen = tmpStr.length();
+         if (tmpStrLen > 0) {
+             tmpStr = tmpStr.toUpper();
+-            const QStringView prefix(tmpStr.left(2));
+-
+             // first, read the type of the recurrence
+             recurrenceTypeAbbrLen = 1;
+             if (tmpStr.at(0) == QLatin1Char('D')) {
+@@ -782,13 +769,13 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
+                 recurrenceType = Recurrence::rWeekly;
+             } else if (tmpStrLen > 1) {
+                 recurrenceTypeAbbrLen = 2;
+-                if (prefix == QLatin1String("MP")) {
++                if (tmpStr.leftRef(2) == QLatin1String("MP")) {
+                     recurrenceType = Recurrence::rMonthlyPos;
+-                } else if (prefix == QLatin1String("MD")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("MD")) {
+                     recurrenceType = Recurrence::rMonthlyDay;
+-                } else if (prefix == QLatin1String("YM")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("YM")) {
+                     recurrenceType = Recurrence::rYearlyMonth;
+-                } else if (prefix == QLatin1String("YD")) {
++                } else if (tmpStr.leftRef(2) == QLatin1String("YD")) {
+                     recurrenceType = Recurrence::rYearlyDay;
+                 }
+             }
+@@ -798,11 +785,7 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
+             // Immediately after the type is the frequency
+             int index = tmpStr.indexOf(QLatin1Char(' '));
+             int last = tmpStr.lastIndexOf(QLatin1Char(' ')) + 1; // find last entry
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-            const int rFreq = QStringView(tmpStr).mid(recurrenceTypeAbbrLen, (index - 1)).toInt();
+-#else
+-            const int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+-#endif
++            int rFreq = tmpStr.midRef(recurrenceTypeAbbrLen, (index - 1)).toInt();
+             ++index; // advance to beginning of stuff after freq
+ 
+             // Read the type-specific settings
+@@ -936,12 +919,8 @@ Event::Ptr VCalFormat::VEventToEvent(VObject *vevent)
+             index = last;
+             if (tmpStr.mid(index, 1) == QLatin1String("#")) {
+                 // Nr of occurrences
+-                ++index;
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-                const int rDuration = QStringView(tmpStr).mid(index, tmpStr.length() - index).toInt();
+-#else
+-                const int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+-#endif
++                index++;
++                int rDuration = tmpStr.midRef(index, tmpStr.length() - index).toInt();
+                 if (rDuration > 0) {
+                     anEvent->recurrence()->setDuration(rDuration);
+                 }
+@@ -1228,22 +1207,24 @@ QString VCalFormat::qDateTimeToISO(const QDateTime &dt, bool zulu)
+ 
+ QDateTime VCalFormat::ISOToQDateTime(const QString &dtStr)
+ {
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-    auto noAllocString = QStringView{dtStr};
+-#else
+-    auto noAllocString = QStringRef(&dtStr);
+-#endif
+-
+-    int year = noAllocString.left(4).toInt();
+-    int month = noAllocString.mid(4, 2).toInt();
+-    int day = noAllocString.mid(6, 2).toInt();
+-    int hour = noAllocString.mid(9, 2).toInt();
+-    int minute = noAllocString.mid(11, 2).toInt();
+-    int second = noAllocString.mid(13, 2).toInt();
+-
+     QDate tmpDate;
+-    tmpDate.setDate(year, month, day);
+     QTime tmpTime;
++    QString tmpStr;
++    int year;
++    int month;
++    int day;
++    int hour;
++    int minute;
++    int second;
++
++    tmpStr = dtStr;
++    year = tmpStr.leftRef(4).toInt();
++    month = tmpStr.midRef(4, 2).toInt();
++    day = tmpStr.midRef(6, 2).toInt();
++    hour = tmpStr.midRef(9, 2).toInt();
++    minute = tmpStr.midRef(11, 2).toInt();
++    second = tmpStr.midRef(13, 2).toInt();
++    tmpDate.setDate(year, month, day);
+     tmpTime.setHMS(hour, minute, second);
+ 
+     if (tmpDate.isValid() && tmpTime.isValid()) {
+@@ -1253,22 +1234,20 @@ QDateTime VCalFormat::ISOToQDateTime(const QString &dtStr)
+         } else {
+             return QDateTime(tmpDate, tmpTime, d->mCalendar->timeZone());
+         }
++    } else {
++        return QDateTime();
+     }
+-
+-    return {};
+ }
+ 
+ QDate VCalFormat::ISOToQDate(const QString &dateStr)
+ {
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-    auto noAllocString = QStringView{dateStr};
+-#else
+-    auto noAllocString = QStringRef(&dateStr);
+-#endif
++    int year;
++    int month;
++    int day;
+ 
+-    const int year = noAllocString.left(4).toInt();
+-    const int month = noAllocString.mid(4, 2).toInt();
+-    const int day = noAllocString.mid(6, 2).toInt();
++    year = dateStr.leftRef(4).toInt();
++    month = dateStr.midRef(4, 2).toInt();
++    day = dateStr.midRef(6, 2).toInt();
+ 
+     return QDate(year, month, day);
+ }
+@@ -1283,7 +1262,7 @@ bool VCalFormat::parseTZOffsetISO8601(const QString &s, int &result)
+     // We also accept broken one without +
+     int mod = 1;
+     int v = 0;
+-    const QString str = s.trimmed();
++    QString str = s.trimmed();
+     int ofs = 0;
+     result = 0;
+ 
+@@ -1308,11 +1287,7 @@ bool VCalFormat::parseTZOffsetISO8601(const QString &s, int &result)
+         return false;
+     }
+ 
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-    v = QStringView(str).mid(ofs, 2).toInt(&ok) * 60;
+-#else
+     v = str.midRef(ofs, 2).toInt(&ok) * 60;
+-#endif
+     if (!ok) {
+         return false;
+     }
+@@ -1326,11 +1301,7 @@ bool VCalFormat::parseTZOffsetISO8601(const QString &s, int &result)
+             if (str.size() < (ofs + 2)) {
+                 return false;
+             }
+-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+-            v += QStringView(str).mid(ofs, 2).toInt(&ok);
+-#else
+             v += str.midRef(ofs, 2).toInt(&ok);
+-#endif
+             if (!ok) {
+                 return false;
+             }
+-- 
+2.25.1
+

--- a/rpm/kf5-calendarcore.spec
+++ b/rpm/kf5-calendarcore.spec
@@ -1,6 +1,6 @@
 Name:       kf5-calendarcore
 Summary:    KDE calendar library
-Version:    5.86.0
+Version:    5.90.0
 Release:    1
 License:    LGPLv2+ and BSD
 URL:        https://invent.kde.org/frameworks/kcalendarcore
@@ -12,9 +12,10 @@ BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(libical)
-BuildRequires:  extra-cmake-modules >= 5.75.0
+BuildRequires:  extra-cmake-modules >= 5.90.0
 
 Patch1: 0001-Adjust-for-lower-Qt-versions.patch
+Patch2: 0002-Revert-Port-QStringRef-deprecated-to-QStringView.patch
 
 %description
 KDE Framework calendar core library


### PR DESCRIPTION
It relies on sailfishos/extra-cmake-modules#2

It is at the moment a simple update to latest upstream, not to lag too much behind.

It may be wise though to wait for https://invent.kde.org/frameworks/kcalendarcore/-/merge_requests/84 to settle (about the listing of cancelled events) before actually do the upgrade here.