### PR TITLE
[kf5-calendarcore] Update upstream to include cancelled status patch.…

### DIFF
--- a/rpm/kf5-calendarcore.spec
+++ b/rpm/kf5-calendarcore.spec
@@ -54,7 +54,6 @@ make install DESTDIR=%{buildroot}
 %defattr(-,root,root,-)
 %{_includedir}/KF5/KCalendarCore
 %{_includedir}/KF5/kcalcore_version.h
-%{_includedir}/KF5/kcalendarcore_version.h
 %{_datadir}/qt5/mkspecs/modules/qt_KCalendarCore.pri
 %{_libdir}/cmake/KF5CalendarCore
 %{_libdir}/libKF5CalendarCore.so


### PR DESCRIPTION
… Contributes to JB#56640

@pvuorela, I've pushed the patch correcting the OccurrenceIterator not listing cancelled exceptions upstream. Hopefully it won't create too many difficulties for KDE... Here is the update of our packaging.

The `kcalendarcore_version.h` file has been moved into `KF5/KCalendarCore/` directory, so there is no need anymore to list it in the spec file.