### PR TITLE
[kf5-calendarcore] Update upstream

### DIFF
--- a/rpm/0001-Adjust-for-lower-Qt-versions.patch
+++ b/rpm/0001-Adjust-for-lower-Qt-versions.patch
@@ -32,7 +32,7 @@ index 406925e2b..f39c15fab 100644
  
  # ECM setup
  include(FeatureSummary)
--find_package(ECM 5.92.0  NO_MODULE)
+-find_package(ECM 5.93.0  NO_MODULE)
 +find_package(ECM 5.89.0  NO_MODULE)
  set_package_properties(ECM PROPERTIES TYPE REQUIRED DESCRIPTION "Extra CMake Modules." URL "https://commits.kde.org/extra-cmake-modules")
  feature_summary(WHAT REQUIRED_PACKAGES_NOT_FOUND FATAL_ON_MISSING_REQUIRED_PACKAGES)
@@ -65,9 +65,9 @@ index 4c821d45b..9bc28ff9c 100644
  void TestDateSerialization::testTodoCompletedOnce()
  {
 +#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-     QDateTime startDate = QDate(2022, 1, 27).startOfDay();
+     QDateTime startDate = QDate(QDate::currentDate().year(), QDate::currentDate().month(), 1).startOfDay();
 +#else
-+    QDateTime startDate { QDate(2022, 1, 27) };
++    QDateTime startDate { QDate(QDate::currentDate().year(), QDate::currentDate().month(), 1) };
 +#endif
      QDateTime dueDate{startDate.addDays(1)};
  

--- a/rpm/kf5-calendarcore.spec
+++ b/rpm/kf5-calendarcore.spec
@@ -1,6 +1,6 @@
 Name:       kf5-calendarcore
 Summary:    KDE calendar library
-Version:    5.92.0
+Version:    5.93.0
 Release:    1
 License:    LGPLv2+
 URL:        https://invent.kde.org/frameworks/kcalendarcore


### PR DESCRIPTION
Bring a fix for notification of change for exceptions
when changing notebook.

Implement notebook association when parsing iCal data.

While not being an upstream update, it already includes two fixes that could be usefull for sailfishos/mkcal#24 and sailfishos/mkcal#25.