### PR TITLE
[kf5-calendarcore] Update to upstream5.94

### DIFF
--- a/rpm/kf5-calendarcore.spec
+++ b/rpm/kf5-calendarcore.spec
@@ -1,6 +1,6 @@
 Name:       kf5-calendarcore
 Summary:    KDE calendar library
-Version:    5.93.0
+Version:    5.94.0
 Release:    1
 License:    LGPLv2+
 URL:        https://invent.kde.org/frameworks/kcalendarcore


### PR DESCRIPTION
This includes a fix when importing ical data
without UID field.

@pvuorela : some very minor changes, but that could be interesting to have. This is fixing for instance importation of faulty ICS files where UID is not provided. I received such files for instance from an airplane compagny for booked tickets. The result was that the importation dialog was only showing (and importing) the go part of the ticket, but not the return. With such fix proposed by upstream, it is working transparently for the user by creating a UID forged from the md5sum of the event before exposing it.